### PR TITLE
Add event trigger for workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Build and publish docs
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   publish:
@@ -51,3 +51,10 @@ jobs:
       - name: Build docs
         run: tox -p auto -o
         working-directory: docs
+
+      # - name: Deploy
+      #   if: github.ref == 'refs/heads/master'
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ./docs/build/html


### PR DESCRIPTION
### Purpose
Enable triggering workflow from other repositories, so when the code changes we rebuild the docs. The way this works, is we can set up the other repos to call the github api when we merge code, sending a `workflow_dispatch` event to the github action defined here. It turns out for this to work, we need to specify the trigger explicitly. We can see this in the test run I did here - https://github.com/Breakthrough-Energy/PostREISE/runs/1119259247

### What it does
Define the new trigger, and add the publish step but leave commented out for now.

### Time to review
3 mins