### PR TITLE
Optional style check

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,15 @@
+name: Check writing style
+
+on: push
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    name: Write good
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npx write-good --parse source/dev/*.md || true


### PR DESCRIPTION
### Purpose
Add a workflow to check writing style using the [write-good](https://github.com/btford/write-good) library. This check will always pass and is meant be be an optional tool to check your writing. As such I haven't put much effort into configuring the types of checks it does, just using the default.

### What it does
Run the tool using `npx` which is a neat way to use npm packages without installing anything. The `--parse` option makes the output more readable - each warning is on a single line and shows the file it came from. Filter to just the directory with contribution guidelines since when I used the `**/*.md` glob it only worked locally, producing no output in github, and this is kind of "for fun" so didn't want to go down a rabbit hole debugging.

### Time to review
2 mins - this is independent of other workflows and has no impact on anything