### PR TITLE
fix: use docker build since it works consistently

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,21 +35,8 @@ jobs:
           token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PreREISE
 
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-            python-version: '3.x'
-
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-
-      - name: Install tox
-        run: |
-          python -m pip install --upgrade pip tox
-        working-directory: docs
-
       - name: Build docs
-        run: tox -p auto -o
+        run: docker-compose up
         working-directory: docs
 
       # - name: Deploy


### PR DESCRIPTION
### Purpose
Make the build work. It started failing and we've been unable to reproduce it locally, but using docker works. It also runs closer to native speed since github agents are linux. Rather than being a backup option, I think this is actually a better choice, since it makes the build pretty close to 100% reproducible.

### What it does
Switch build step to docker, remove now unnecessary steps.

### Time to review
2 min