### PR TITLE
Enable docs publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,9 @@ jobs:
         run: docker-compose up
         working-directory: docs
 
-      # - name: Deploy
-      #   if: github.ref == 'refs/heads/master'
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./docs/build/html
+      - name: Deploy
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html


### PR DESCRIPTION
### Purpose
Make the docs public. They will be rebuilt anytime the workflow is run on master branch, so it will be triggered by merges in this repo as well as merges to the various code repos (via workflow dispatch api). 

### Time to review
2 min