### PR TITLE
fix: mount the volume so package is accessible within build container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
       - ../PowerSimData:/PowerSimData
       - ../PreREISE:/PreREISE
       - ../PostREISE:/PostREISE
+      - ../REISE.jl:/REISE.jl


### PR DESCRIPTION
### Purpose
Add the bind mount, fixing broken link to reise_package. This is also relevant for local builds, so I tested that it works in that case.

### Time to review
1 min