### PR TITLE
ci: remove obsolete token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,28 +18,24 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/PostREISE
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PostREISE
 
       - name: Checkout PowerSimData
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/PowerSimData
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PowerSimData
 
       - name: Checkout PreREISE
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/PreREISE
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PreREISE
 
       - name: Checkout REISE.jl
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/REISE.jl
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: REISE.jl
 
       - name: Build docs


### PR DESCRIPTION
### Purpose
Remove token used to clone previously private repositories

### Testing
The green check mark

### Time estimate
1 min