### PR TITLE
Link to PowerSimData tutorial

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -6,7 +6,8 @@
 
 Facilitating the Energy Transition
 ==================================
-You are familiar with our mission and you just want to install the software, add features or access the documentation? The quick links below will then come up handy:
+You are familiar with our mission and you just want to install the software, add
+features or access the documentation? The quick links below will then come up handy:
 
 * :doc:`user/installation_guide`
 * :doc:`communication/code_of_conduct`
@@ -18,29 +19,60 @@ You are familiar with our mission and you just want to install the software, add
 
 Our Mission
 -----------
-We are a team of research scientists and software engineers who aim to help facilitate the energy transition by developing a model of the U.S electric grid that can integrate clean energy technologies and predict how the system will perform. We belong to the `Breakthrough Energy <https://www.breakthroughenergy.org/>`_ Community and have already conducted several studies that are presented on our `website <https://science.breakthroughenergy.org/>`_. You will find there a nice overview of our goals, the questions we try to answer, the model we developed and cool visualizations that clearly communicate our results.
+We are a team of research scientists and software engineers who aim to help facilitate
+the energy transition by developing a model of the U.S electric grid that can integrate
+clean energy technologies and predict how the system will perform. We belong to the
+`Breakthrough Energy <https://www.breakthroughenergy.org/>`_ network and have already
+conducted several studies that are presented on our `website
+<https://science.breakthroughenergy.org/>`_. You will find there a nice overview of our
+goals, the questions we try to answer, the model we developed and cool visualizations
+that clearly communicate our results.
 
-Our model is open source and is available for download on `GitHub <https://github.com/Breakthrough-Energy>`_. We try here to encourage you to contribute to our project. Since we started this effort, we mainly focused on developing the model and running meaningful scenarios. As a result, our software is not easily installable and deployable. The team has grown and we are now creating a better user experience. While we make this happen, we created this webpage to help you install the software and show you how you can contribute to this effort with the Breakthrough Energy Sciences team. Here is what you will find on `GitHub <https://github.com/Breakthrough-Energy>`_:
+Our model is open source and is available for download on `GitHub
+<https://github.com/Breakthrough-Energy>`_. We try here to encourage you to contribute
+to our project. Since we started this effort, we mainly focused on developing the model
+and running meaningful scenarios. As a result, our software is not easily installable
+and deployable. The team has grown and we are now creating a better user experience.
+While we make this happen, we created this webpage to help you install the software and
+show you how you can contribute to this effort with the Breakthrough Energy Sciences
+team. Here is what you will find on GitHub:
 
-+ The :doc:`powersimdata_package` package - we start with this one since it includes the model, i.e., the synthetic U.S. electric grid, and our simulation platform
-+ The :doc:`prereise_package` package - you will find there the routines to generate the demand, hydro, solar and wind profiles, a.k.a, the scenario input data
-+ The :doc:`postreise_package` package that takes care of the analysis of the scenario output data and the plotting
-+ The :doc:`reisejl_package` package - this is our simulation engine
+- The `PowerSimData <https://github.com/Breakthrough-Energy/PowerSimData>`_ package -
+  we start with this one since it includes the model, i.e., the synthetic U.S. electric
+  grid, and our simulation platform
+- The `PreREISE <https://github.com/Breakthrough-Energy/PreREISE>`_ package - you will
+  find there the routines to generate
+  the demand, hydro, solar and wind profiles, a.k.a, the scenario input data
+- The `PostREISE <https://github.com/Breakthrough-Energy/PostREISE>`_ package that
+  handles the analysis of the scenario output data and the plotting
+- The `REISE.jl <https://github.com/Breakthrough-Energy/REISE.jl>`_ package - this is
+  our simulation engine
 
-The first three packages are written in Python. The last one, the simulation engine, is written in Julia. You are welcome to contribute to any of these packages. In the next section we present the overall architecture and the installation. We wrote a :doc:`dev/contribution_guide` to help us to work together efficiently.
+The first three packages are written in Python. The last one, the simulation engine, is
+written in Julia. You are welcome to contribute to any of these packages. In the next
+section we present the overall architecture and the installation. We wrote a
+:doc:`dev/contribution_guide` to help us to work together efficiently.
 
 
 How it Works
 ------------
-We built a simulation framework in order to perform power flow study in the U.S. electrical grid. The framework and the available features are presented in the README of the :doc:`powersimdata_package` package. There are a few options for using the framework, each with different advantages. We provide more detailed information in the :doc:`installation guide <user/installation_guide>`.
+We built a simulation framework in order to perform power flow study in the U.S.
+electrical grid. The framework and the available features are presented in the
+:doc:`powersimdata/index` tutorial. There are a few options for using the framework,
+each with different advantages. We provide more detailed information in the
+:doc:`user/installation_guide`.
 
-Note that in any case, you should have a `Gurobi <https://www.gurobi.com>`_ license - this is the mathematical solver that our engine use to find power flow solutions to the DC Optimal Power Flow (DCOPF) problems. Note: other solvers will be supported in the future.
+Note that in any case, you should have a `Gurobi <https://www.gurobi.com>`_ license -
+this is the mathematical solver that our engine use to find power flow solutions to the
+DC Optimal Power Flow (DCOPF) problems. Note: other solvers will be supported in the
+future.
 
 
 Communication Channels
 ----------------------
-`Sign up <http://science.breakthroughenergy.org#get-updates>`_ to our email list to stay updated.
-Indicate if you also want to join our Slack workspace to participate in the community.
+`Sign up <http://science.breakthroughenergy.org#get-updates>`_ to our email list to stay
+updated. Indicate if you also want to join our Slack workspace to participate in the
+community.
 
 Please review our :doc:`communication/code_of_conduct` before contributing.
 
@@ -53,7 +85,7 @@ Please review our :doc:`communication/code_of_conduct` before contributing.
    communication/code_of_conduct
    dev/contribution_guide
    user/git_guide
-   powersimdata_package.md
+   powersimdata/index
    prereise_package.md
    postreise_package.md
    reisejl_package.md

--- a/source/powersimdata
+++ b/source/powersimdata
@@ -1,0 +1,1 @@
+../../PowerSimData/docs/

--- a/source/powersimdata_package.md
+++ b/source/powersimdata_package.md
@@ -1,1 +1,0 @@
-../../PowerSimData/README.md

--- a/source/user/installation_guide.rst
+++ b/source/user/installation_guide.rst
@@ -32,7 +32,7 @@ On Laptop/Desktop
       file enclosing the change table listing the transformation applied to the
       original grid
     + Set ``OUTPUT_DIR``: all scenario outputs are stored there after being extracted -
-      the list of output data is given in the :doc:`../powersimdata_package` README
+      the list of output data is given in the :doc:`../powersimdata/index` tutorial
     + Set ``MODEL_DIR``: this directory encloses the simulation engine
     + Set ``LOCAL_DIR``: this directory will enclose your local file system
     + Note that ``BACKUP_DATA_ROOT_DIR`` does not need to be set unless you have a
@@ -66,7 +66,7 @@ repository, along with usage examples.
 
 How to Run Scenario
 -------------------
-Follow the instructions in the :doc:`../powersimdata_package` README.
+Follow the instructions in the :doc:`../powersimdata/scenario` tutorial.
 
 
 .. _GitHub: https://github.com/Breakthrough-Energy


### PR DESCRIPTION
### Purpose
Once we merge https://github.com/Breakthrough-Energy/PowerSimData/pull/432, we want to access the PowerSimData tutorial that is no longer located in the README of PowerSimData.

### Where to look
* Update link in the `toctree` directive of the ***index.rst*** file
* Update some links in the installation guide

### Testing
Checkout this branch along with the `ben/readme` branch in the **PowerSimData** repo and run `tox` there to make sure that the PowerSimData tutorial displays correctly. 

### Time estimate
5 min

### Note
https://github.com/Breakthrough-Energy/PowerSimData/pull/432 and this PR will be merged back to back.