### PR TITLE
Feat: Add Mermaid Diagrams

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 autodoc
 recommonmark
 sphinx-markdown-tables
+sphinxcontrib.mermaid

--- a/source/conf.py
+++ b/source/conf.py
@@ -214,3 +214,7 @@ epub_exclude_files = ["search.html"]
 
 # -- Extension configuration -------------------------------------------------
 todo_include_todos = True
+
+import errno
+import sphinx.util.osutil
+sphinx.util.osutil.ENOENT = errno.ENOENT

--- a/source/conf.py
+++ b/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "recommonmark",
     "sphinx_markdown_tables",
     "sphinx.ext.todo",
+    "sphinxcontrib.mermaid"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/index.rst
+++ b/source/index.rst
@@ -48,6 +48,28 @@ team. Here is what you will find on GitHub:
 - The `REISE.jl <https://github.com/Breakthrough-Energy/REISE.jl>`_ package - this is
   our simulation engine
 
+.. mermaid::
+
+    flowchart TD
+        subgraph M[PreREISE]
+        B["Prepare time series data
+        and other data input"]
+	end
+
+	B -.".csv".-> C[Create]
+	subgraph N[PowerSimData]
+	C --".mat and .csv"--> D[Execute]
+	D --".pkl"--> E[Analyze]
+	end
+	subgraph O[REISE.jl]
+	F["Simulation Engine to translate
+	the optimization problem to solver"]
+	end
+	D <--> O
+	subgraph P[PostREISE]
+	E --> G["Optional output analysis and plotting"]
+	end
+
 The first three packages are written in Python. The last one, the simulation engine, is
 written in Julia. You are welcome to contribute to any of these packages. In the next
 section we present the overall architecture and the installation. We wrote a

--- a/source/index.rst
+++ b/source/index.rst
@@ -52,23 +52,27 @@ team. Here is what you will find on GitHub:
 
     flowchart TD
         subgraph M[PreREISE]
-        B["Prepare time series data
+        B["Prepare time series .csv's
         and other data input"]
-	end
+        end
 
-	B -.".csv".-> C[Create]
-	subgraph N[PowerSimData]
-	C --".mat and .csv"--> D[Execute]
-	D --".pkl"--> E[Analyze]
-	end
-	subgraph O[REISE.jl]
-	F["Simulation Engine to translate
-	the optimization problem to solver"]
-	end
-	D <--> O
-	subgraph P[PostREISE]
-	E --> G["Optional output analysis and plotting"]
-	end
+        subgraph N[PowerSimData]
+        C[Create] --> D[Execute]
+        D
+        E[Analyze]
+        end
+
+        B ----> N
+        subgraph O[REISE.jl]
+        F["Simulation Engine to translate
+        the optimization problem to solver"]
+        end
+        D --".mat and .csv"--> O
+        O --".pkl"--> E
+        subgraph P[PostREISE]
+        G["Optional output analysis and plotting"]
+        end
+        E ----> P	
 
 The first three packages are written in Python. The last one, the simulation engine, is
 written in Julia. You are welcome to contribute to any of these packages. In the next


### PR DESCRIPTION
### Purpose
Add mermaid diagrams to the documentation

### What the code is doing
Mermaid cli has been added as a sphinx extension, and the dockerfile has been updated to include mermaid in the build. There is a diagram added to the landing page showing the interactions between the different repos.

### Testing
Both running `tox` locally and `docker-compose up --build` successfully build the expected docs with the embedded diagram.

### Time estimate
5 min
