### PR TITLE
PreREISE profiles generation

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -106,6 +106,7 @@ Please review our :doc:`communication/code_of_conduct` before contributing.
 .. toctree::
    :maxdepth: 3
    :hidden:
+   :numbered:
 
    user/installation_guide
    communication/code_of_conduct

--- a/source/index.rst
+++ b/source/index.rst
@@ -112,6 +112,6 @@ Please review our :doc:`communication/code_of_conduct` before contributing.
    dev/contribution_guide
    user/git_guide
    powersimdata/index
-   prereise_package.md
+   prereise/index
    postreise/index
    reisejl_package.md

--- a/source/prereise
+++ b/source/prereise
@@ -1,0 +1,1 @@
+../../PreREISE/docs/

--- a/source/prereise_package.md
+++ b/source/prereise_package.md
@@ -1,1 +1,0 @@
-../../PreREISE/README.md


### PR DESCRIPTION
### Purpose
Link to newly created PreREISE docs (see https://github.com/Breakthrough-Energy/PreREISE/pull/187)

### Where to look
* Create a symbolic link to the PreREISE docs folder
* Remove the symbolic link to the README
* Update path in **index.rst**
* Add automatically numbering of section for clarity

### Testing
Run `tox` to generate the documentation

### Time estimate
5 min