### PR TITLE
Add reliability assessment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 source/postreise.*
 source/powersimdata.*
 source/prereise.*
+source/reliabilityassessment.*
 source/modules.rst
 source/setup.rst
 source/test.rst

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,11 +18,13 @@ import sys
 sys.path.insert(0, os.path.abspath("../../PreREISE"))
 sys.path.insert(0, os.path.abspath("../../PowerSimData"))
 sys.path.insert(0, os.path.abspath("../../PostREISE"))
+sys.path.insert(0, os.path.abspath("../../reliability-assessment"))
 
 import warnings
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
 warnings.filterwarnings("ignore", message="Container node skipped")
 
 # -- General configuration ---------------------------------------------------
@@ -66,10 +68,16 @@ language = "en"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
     "_build",
+    "conftest.rst",
     "modules.rst",
     "setup.rst",
+    "prereise/hydro/legacy/capacity_factor.rst",
+    "prereise/renewables/solar/wind.rst",
     "prereise/demand/transportation_electrification/data.rst",
     "prereise/demand/transportation_electrification/methodology.rst",
+    "prereise.gather.flexibilitydata.doe.examples.rst",
+    "postreise/README.md"
+    "reliabilityassessment/usage.rst",
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.
@@ -115,7 +123,6 @@ html_theme_options = {
     "fixed_sidebar": False,
     "sidebar_width": "20%",
     "page_width": "80%",
-    "page_width": "auto",
     "github_button": True,
     "github_user": "Breakthrough-Energy",
     "github_repo": "docs",

--- a/source/index.rst
+++ b/source/index.rst
@@ -124,3 +124,4 @@ Please review our :doc:`communication/code_of_conduct` before contributing.
    prereise/index
    postreise/index
    reisejl/index
+   reliabilityassessment/index

--- a/source/reliabilityassessment
+++ b/source/reliabilityassessment
@@ -1,0 +1,1 @@
+../../reliability-assessment/docs/

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = {prereise,powersimdata,postreise}
+envlist = {reliabilityassessment,powersimdata,prereise,postreise}
 skipsdist = True
 
 [testenv]
 allowlist_externals = make
-setenv = 
+setenv =
+    {reliabilityassessment}: PROJECT_DIR = reliability-assessment
     {prereise}: PROJECT_DIR = PreREISE
-    {powersimdata}: PROJECT_DIR = PowerSimData
     {postreise}: PROJECT_DIR = PostREISE
-passenv = 
+    {powersimdata}: PROJECT_DIR = PowerSimData
+passenv =
     CPPFLAGS
     LDFLAGS
 commands =


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add reliability assessment documentation to website. Note that docstring are poorly formatted and do not render well. This will need to be fixed at some point.

### What the code is doing
N/A

### Testing
Generated documentation locally successfully. 

### Where to look


### Usage Example/Visuals
See content of [PR #99](https://github.com/Breakthrough-Energy/reliability-assessment/pull/99) in reliability-assessment repo.

### Time estimate
5min
